### PR TITLE
added config to model_settings to fix async issue w/ tool calls

### DIFF
--- a/backend/routes/chat.py
+++ b/backend/routes/chat.py
@@ -1,4 +1,3 @@
-# backend/routes/chat.py
 from fastapi import APIRouter, Depends, Request
 from fastapi.responses import StreamingResponse
 from sqlalchemy.ext.asyncio import AsyncSession

--- a/backend/services/chat.py
+++ b/backend/services/chat.py
@@ -46,7 +46,10 @@ class ChatService:
         self.agent = Agent(
             "openai:gpt-4o",
             end_strategy="exhaustive",
-            retries=2
+            retries=2,
+            model_settings={
+                "parallel_tool_calls": False  
+            }
         )
 
         self._register_tools()


### PR DESCRIPTION
I set parallel_tool_calls to false in model settings to fix the async errors that occur when pydantic-ai tries to reuse the same async db session for multiple parallel calls at once. 